### PR TITLE
Fixed shared log path on Windows

### DIFF
--- a/src/Rocketeer/Rocketeer.php
+++ b/src/Rocketeer/Rocketeer.php
@@ -145,7 +145,7 @@ class Rocketeer
 
 		// Add logs to shared folders
 		$shared = (array) $this->getOption('remote.shared');
-		$shared[] = trim($logs, '/');
+		$shared[] = trim(str_replace('\\', '/', $logs), '/');
 
 		return $shared;
 	}


### PR DESCRIPTION
Found another instance where paths were broken on windows.
