### PR TITLE
fixed Anahkiasen/rocketeer#35

### DIFF
--- a/src/Rocketeer/Rocketeer.php
+++ b/src/Rocketeer/Rocketeer.php
@@ -3,6 +3,7 @@ namespace Rocketeer;
 
 use Illuminate\Container\Container;
 use Illuminate\Support\Str;
+use \ReflectionException;
 
 /**
  * Handles interaction between the User provided informations
@@ -211,7 +212,12 @@ class Rocketeer
 		return preg_replace_callback('/\{[a-z\.]+\}/', function ($match) use ($app) {
 			$folder = substr($match[0], 1, -1);
 
-			if (isset($app[$folder])) {
+			try {
+				$app_folder = $app[$folder];
+			} catch(\ReflectionException $e) {
+				return false;
+			}
+			if (isset($app_folder)) {
 				return str_replace($app['path.base'].'/', null, $app->make($folder));
 			}
 

--- a/tests/ReleasesManagerTest.php
+++ b/tests/ReleasesManagerTest.php
@@ -56,6 +56,6 @@ class ReleasesManagerTest extends RocketeerTests
 	{
 		$folder = $this->app['rocketeer.releases']->getCurrentReleasePath('{path.storage}');
 
-		$this->assertEquals($this->server.'/releases/20000000000000/storage', $folder);
+		$this->assertEquals($this->server.'/releases/20000000000000/app/storage', $folder);
 	}
 }

--- a/tests/RocketeerTest.php
+++ b/tests/RocketeerTest.php
@@ -97,7 +97,7 @@ class RocketeerTest extends RocketeerTests
 	{
 		$folder = $this->app['rocketeer.rocketeer']->getFolder('{path.storage}');
 
-		$this->assertEquals($this->server.'/storage', $folder);
+		$this->assertEquals($this->server.'/app/storage', $folder);
 	}
 
 	public function testCannotReplaceUnexistingPatternsInFolders()

--- a/tests/_start.php
+++ b/tests/_start.php
@@ -52,10 +52,10 @@ abstract class RocketeerTests extends PHPUnit_Framework_TestCase
 
 		// Laravel classes --------------------------------------------- /
 
-		$this->app['path.base']    = '/src';
-		$this->app['path']         = '/src/app';
-		$this->app['path.public']  = '/src/public';
-		$this->app['path.storage'] = '/src/storage';
+		$this->app->instance('path.base', '/src');
+		$this->app->instance('path', '/src/app');
+		$this->app->instance('path.public', '/src/public');
+		$this->app->instance('path.storage', '/src/app/storage');
 
 		$this->app['files']   = new Filesystem;
 		$this->app['config']  = $this->getConfig();


### PR DESCRIPTION
Hello Anahkiasen.

I'm sorry for my bad english.
This is my first PullRequest.

I solved Anahkiasen/rocketeer#35 in my environment.
php 5.5.3
Laravel 4.0.7
rocketeer 0.7.0

I think this problem caused by below line.
[src/Rocketeer/Rocketeer.php#L214](https://github.com/Anahkiasen/rocketeer/blob/b16fdc316a6f66413eb9925477095af5edc0b07f/src/Rocketeer/Rocketeer.php#L214)

``` php
if (isset($app[$folder])) {...}
```

In actual laravel apps are `isset($app[$folder])` returns false ($folder=path.storage, path.public... etc).
But, `var_dump($app[$folder])` returns valid paths! (This is very magically for me.)

It is because actual apps registers paths in `bootstrap/start.php`. [original](https://github.com/laravel/laravel/blob/master/bootstrap/start.php#L46)
(Artisan command also read this file.)

This file call `Illuminate\Foundation\Application::bindInstallPaths()` method. 
`bindInstallPaths()` call `Illuminate\Container\Container::instance()` method.
Does not directly assignment like `$app['path.base'] = '...'`.

Please check below classes and methods.

``` php
Illuminate\Container\Container::instance()
Illuminate\Container\Container::offsetExists()
Illuminate\Container\Container::offsetGet()
Illuminate\Foundation\Application::bindInstallPaths()
```

cheer!
