### PR TITLE
SVN scm adapder

### DIFF
--- a/src/Rocketeer/Scm/Svn.php
+++ b/src/Rocketeer/Scm/Svn.php
@@ -80,7 +80,8 @@ class Svn extends Scm implements ScmInterface
 	 */
 	public function reset()
 	{
-		return $this->getCommand('revert -R .');
+		$cmd = 'status -q | grep -v \'^[~XI ]\' | awk \'{print $2;}\' | xargs %s revert';
+		return $this->getCommand(sprintf($cmd, $this->binary));
 	}
 
 	/**


### PR DESCRIPTION
Tested under Debian 6 and FreeBSD 8.2

Method getCredentials() has been added because svn:// and http:// propocols very used but Rocketeer::getRepository() set credentials only for httpS://
