### PR TITLE
Reusing getAvailableConnections() to avoid conflicts

### DIFF
--- a/src/Rocketeer/Commands/BaseDeployCommand.php
+++ b/src/Rocketeer/Commands/BaseDeployCommand.php
@@ -104,7 +104,7 @@ abstract class BaseDeployCommand extends Command
 			$this->laravel['config']->set('rocketeer::scm.'.$key, $credential);
 		}
 	}
-
+	
 	/**
 	 * Get the Server's credentials
 	 *
@@ -117,15 +117,15 @@ abstract class BaseDeployCommand extends Command
 		}
 
 		// Check for configured connections
+		$availableConnections = $this->laravel['rocketeer.rocketeer']->getAvailableConnections();
 		$activeConnections = $this->laravel['rocketeer.rocketeer']->getConnections();
 
 		if (count($activeConnections) <= 0) {
 			$connectionName = $this->ask('No connections have been set, please create one : (production)', 'production');
-			$this->storeServerCredentials($connectionName);
+			$this->storeServerCredentials($availableConnections, $connectionName);
 		} else {
-			// Veritfy and store each valid connection
 			foreach ($activeConnections as $connectionName) {
-				$this->storeServerCredentials($connectionName);
+				$this->storeServerCredentials($availableConnections, $connectionName);
 			}
 		}
 	}
@@ -137,10 +137,9 @@ abstract class BaseDeployCommand extends Command
 	 *
 	 * @return void
 	 */
-	private function storeServerCredentials($connectionName)
+	private function storeServerCredentials($connections, $connectionName)
 	{
 		// Check for server credentials
-		$connections = $this->laravel['rocketeer.rocketeer']->getAvailableConnections();
 		$connection  = array_get($connections, $connectionName, array());
 		$credentials = array('host' => true, 'username' => true, 'password' => false, 'keyphrase' => null, 'key' => false);
 


### PR DESCRIPTION
Even though I tested several times that my previous pull request was working as expected, I just started having issues again - I suspect that my cache hadn't been properly cleaned when I performed tests for the previous pull request.

This change "caches" `getAvailableConnections()`, this is necessary because:
- The first call to `getAvailableConnections()` fetches connections from the remote config
- Subsequent calls uses Rocketeers own list of available connections
- The end of `storeServerCredentials()` creates this list and thus overrides the remote config.

This prevented the next items in the list from using already stored credentials, thus resulting in Rocketeer asking for hostname, etc.

I hope that this is the end of that issue :)
