### PR TITLE
Fix inline statement not working in FreeBSD

### DIFF
--- a/src/Rocketeer/Bash.php
+++ b/src/Rocketeer/Bash.php
@@ -319,7 +319,7 @@ class Bash extends AbstractLocatorClass
 	 */
 	public function fileExists($file)
 	{
-		$exists = $this->runRaw('if [ -e ' .$file. ' ]; then echo "true"; fi');
+		$exists = $this->runRaw('[ -e ' .$file. ' ] && echo "true"');
 
 		return trim($exists) == 'true';
 	}


### PR DESCRIPTION
I had issues on FreeBSD, the symlinks was not create. I investigate and find out the inline statement in the function fileExists() returned an error.
