### PR TITLE
fix miss $_SERVER['HOME'] error on Windows

### DIFF
--- a/src/Rocketeer/Server.php
+++ b/src/Rocketeer/Server.php
@@ -130,7 +130,7 @@ class Server
 	{
 		// Create personnal storage if necessary
 		if (!$this->app->bound('path.storage')) {
-			$storage = $_SERVER['HOME'].'/.rocketeer';
+			$storage = (isset($_SERVER['HOME']) ? $_SERVER['HOME'] : '.').'/.rocketeer';
 			@mkdir($storage);
 		}
 


### PR DESCRIPTION
when run depoy on Windows, will raise a undefined index $_SERVER['HOME'] error
