### PR TITLE
Fixed trailing slashes with log files path

### DIFF
--- a/src/Rocketeer/Igniter.php
+++ b/src/Rocketeer/Igniter.php
@@ -134,7 +134,8 @@ class Igniter
 	protected function bindConfiguration()
 	{
 		$path = $this->app['path.base'] ? $this->app['path.base'].'/' : '';
-		$logs = $this->app->bound('path.storage') ? str_replace($path, null, $this->app['path.storage']) : '.rocketeer';
+		$logs = $this->app->bound('path.storage') ? str_replace($this->unifySlashes($path), null, $this->unifySlashes($this->app['path.storage'])) : '.rocketeer';
+
 		$paths = array(
 			'config' => '.rocketeer',
 			'events' => '.rocketeer/events',
@@ -158,5 +159,15 @@ class Igniter
 
 			$this->app->instance('path.rocketeer.'.$key, $filename);
 		}
+	}
+	
+	/**
+	 * Unify the slashes to the UNIX mode (forward slashes)
+	 * @param  string $path
+	 * @return string
+	 */
+	protected function unifySlashes($path)
+	{
+		return str_replace('\\', '/', $path);
 	}
 }


### PR DESCRIPTION
There was an error when trying to obtain the path to log files in Windows.
The code

<pre>
    str_replace($path, null, $this->app['path.storage'])
</pre>

was not running well in Windows due to the fact that $path is "C:\wamp\www/" and $this->app['path.storage'] is "C:\wamp\www\app\storage".

The fixed forces all the paths to use forward slashes.
