### PR TITLE
Check if dir exists before glob()

### DIFF
--- a/src/Rocketeer/RocketeerServiceProvider.php
+++ b/src/Rocketeer/RocketeerServiceProvider.php
@@ -359,7 +359,7 @@ class RocketeerServiceProvider extends ServiceProvider
 		}
 
 		// Else include its contents
-		else {
+		elseif (is_dir($file)) {
 			$folder = glob($file.'/*.php');
 			foreach ($folder as $file) {
 				include $file;


### PR DESCRIPTION
I get an Invalid argument supplied for foreach() exception otherwise (on 1 system, other system works fine) (on develop this time)
