### PR TITLE
Fix bug with instanceof

### DIFF
--- a/src/Rocketeer/TasksQueue.php
+++ b/src/Rocketeer/TasksQueue.php
@@ -369,7 +369,7 @@ class TasksQueue extends AbstractLocatorClass
 	 */
 	public function buildTaskFromClass($task)
 	{
-		if ($task instanceof Task) {
+		if (is_object($task) and $task instanceof Task) {
 			return $task;
 		}
 


### PR DESCRIPTION
The `$task` variable is a string. And if its value is a class name which extends `Rocketeer\Traits\Task`, instanceof will return `true` (see [documentation](http://www.php.net/manual/en/language.operators.type.php)) and method will return a string instead of expected object.
