### PR TITLE
Run composer install with --no-interaction and optionally with --no-dev as discussed in anahkiasen/rocketeer#162

### DIFF
--- a/src/Rocketeer/Traits/BashModules/Binaries.php
+++ b/src/Rocketeer/Traits/BashModules/Binaries.php
@@ -146,9 +146,15 @@ class Binaries extends Filesystem
 			return true;
 		}
 
+		// Composer command-line options
+		$options = ' --no-interaction';
+		if ($this->app['rocketeer.rocketeer']->getOption('remote.composer_nodev')) {
+			$options .= ' --no-dev';
+		}
+
 		// Run install
 		$this->command->comment('Installing Composer dependencies');
-		$output = $this->runForCurrentRelease($this->getComposer(). ' install');
+		$output = $this->runForCurrentRelease($this->getComposer(). ' install' . $options);
 
 		return $this->checkStatus('Composer could not install dependencies', $output);
 	}

--- a/src/config/remote.php
+++ b/src/config/remote.php
@@ -13,6 +13,9 @@
 	// The root directory where your applications will be deployed
 	'root_directory'   => '/home/www/',
 
+	// If true, skip installing composer packages listed in require-dev
+	'composer_nodev' => false,
+
 	// The name of the application to deploy
 	// This will create a folder of the same name in the root directory
 	// configured above, so be careful about the characters used


### PR DESCRIPTION
I have added --no-interaction to composer install and a config option for --no-dev (default value mantains current behavior)
