### PR TITLE
Fixed a bug that does not allow to run deploy with option seed

### DIFF
--- a/src/Rocketeer/Commands/DeployCommand.php
+++ b/src/Rocketeer/Commands/DeployCommand.php
@@ -53,10 +53,10 @@ class DeployCommand extends AbstractDeployCommand
 	protected function getOptions()
 	{
 		return array_merge(parent::getOptions(), array(
-			array('tests',     't',  InputOption::VALUE_NONE,     'Runs the tests on deploy'),
-			array('migrate',   'm',  InputOption::VALUE_NONE,     'Run the migrations'),
-			array('seed',      's',  InputOption::VALUE_OPTIONAL, 'Seed the database (after migrating it if --migrate)'),
-			array('clean-all', null, InputOption::VALUE_NONE,     'Cleanup all but the current release on deploy'),
+			array('tests',     't',  InputOption::VALUE_NONE,    'Runs the tests on deploy'),
+			array('migrate',   'm',  InputOption::VALUE_NONE,    'Run the migrations'),
+			array('seed',      's',  InputOption::VALUE_NONE,    'Seed the database (after migrating it if --migrate)'),
+			array('clean-all', null, InputOption::VALUE_NONE,    'Cleanup all but the current release on deploy'),
 		));
 	}
 }

--- a/src/Rocketeer/Traits/BashModules/Binaries.php
+++ b/src/Rocketeer/Traits/BashModules/Binaries.php
@@ -93,7 +93,7 @@ class Binaries extends Filesystem
 	 *
 	 * @return string
 	 */
-	public function seed($class = null)
+	public function runSeed($class = null)
 	{
 		$this->command->comment('Seeding database');
 		$flags = $class ? array('class' => $class) : array();

--- a/tests/Tasks/DeployTest.php
+++ b/tests/Tasks/DeployTest.php
@@ -160,4 +160,36 @@ class DeployTest extends RocketeerTestCase
 			'migrate' => false
 		));
 	}
+
+	public function testCanRunDeployWithSeed()
+	{
+		$matcher = array(
+			'git clone --depth 1 -b master "" {server}/releases/{release}',
+			array(
+				"cd {server}/releases/{release}",
+				"git submodule update --init --recursive"
+			),
+			array(
+				"cd {server}/releases/{release}",
+				"chmod -R 755 {server}/releases/{release}/tests",
+				"chmod -R g+s {server}/releases/{release}/tests",
+				"chown -R www-data:www-data {server}/releases/{release}/tests"
+			),
+			array(
+				"cd {server}/releases/{release}",
+				"{php} artisan db:seed"
+			),
+			"mkdir -p {server}/shared/tests",
+			"mv {server}/releases/{release}/tests/Elements {server}/shared/tests/Elements",
+			"mv {server}/current {server}/releases/{release}",
+			"rm -rf {server}/current",
+			"ln -s {server}/releases/{release} {server}/current",
+		);
+
+		$this->assertTaskHistory('Deploy', $matcher, array(
+			'tests'   => false,
+			'seed'    => true,
+			'migrate' => false,
+		));
+	}
 }


### PR DESCRIPTION
Hello 
I found a bug not allowing to run deploy with option "seed". 
I found the problem and corrected it.
I also discovered that the default option is "seed" was null, while in the tests it is set to false by default. Because of this behavior in the tests and run was different. This problem is also fixed.
