### PR TITLE
Added default path for 'artisan' based on a standard Laravel deployment.

### DIFF
--- a/src/Rocketeer/Traits/BashModules/Binaries.php
+++ b/src/Rocketeer/Traits/BashModules/Binaries.php
@@ -47,7 +47,7 @@ class Binaries extends Filesystem
 	 */
 	public function artisan($command = null, $flags = array())
 	{
-		$artisan = $this->which('artisan') ?: 'artisan';
+		$artisan = $this->which('artisan', $this->releasesManager->getCurrentReleasePath()."/artisan") ?: 'artisan';
 		foreach ($flags as $name => $value) {
 			$command .= ' --'.$name;
 			$command .= $value ? '="' .$value. '"' : '';


### PR DESCRIPTION
Rocketeer tries to locate 'artisan' from the different search paths and, if it doesn't succeed, uses the fallback of <current_release>/artisan.
If the file is not there (as would happen in a --pretend run), prompt is still shown to allow the introduction of the correct path.

Originally it seemed to always expect 'artisan' path either explicitely or as a global installation.
