### PR TITLE
Remove PHP 5.3 from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6


### PR DESCRIPTION
Laravel 4.2 requires PHP 5.4 or later, causing Travis to fail when trying to composer install dependencies.

Your requirements could not be resolved to an installable set of packages.
Problem 1
- Installation request for illuminate/config v4.2.1 -> satisfiable by illuminate/config[v4.2.1].
- illuminate/config v4.2.1 requires php >=5.4.0 -> no matching package found.

................
