### PR TITLE
Fixing composer branch alias.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "1.3-dev"
+			"dev-master": "1.2-dev"
 		}
 	}
 }


### PR DESCRIPTION
Currently the master and develop branches both try to alias dev-develop to 1.3-dev and 2.0-dev. This is not possible, nor makes any sense.

This leads to 2.0._@dev existing on packagist, but not 1.3._@dev and ends up causing people to use dev-master which is bad.

This fixes that, allowing users to now require 1.3.*@dev
