### PR TITLE
Suppress output during the tests

### DIFF
--- a/tests/Tasks/CleanupTest.php
+++ b/tests/Tasks/CleanupTest.php
@@ -30,11 +30,15 @@ class CleanupTest extends RocketeerTestCase
 				});
 		});
 
+		ob_start();
+
 		$this->assertTaskOutput('Cleanup', 'Removing <info>2 releases</info> from the server', $this->getCommand(array(), array(
 			'clean-all' => true,
 			'verbose'   => true,
 			'pretend'   => false,
 		)));
+
+		ob_end_clean();
 	}
 
 	public function testPrintsMessageIfNoCleanup()


### PR DESCRIPTION
This should solve the issue where we have blank lines generated dumped while the test suite it running.
