### PR TITLE
Fixes deploy hooks not firing when single connection is set

### DIFF
--- a/src/Rocketeer/Services/Connections/ConnectionsHandler.php
+++ b/src/Rocketeer/Services/Connections/ConnectionsHandler.php
@@ -293,7 +293,7 @@ class ConnectionsHandler
 	 */
 	public function setConnection($connection, $server = 0)
 	{
-		if (!$this->isValidConnection($connection) || $this->connection == $connection) {
+		if (!$this->isValidConnection($connection) && $this->connection == $connection) {
 			return;
 		}
 


### PR DESCRIPTION
Issue: https://github.com/rocketeers/rocketeer/issues/304

I think this is what is needed to fix the above issue when there is only a single connection set.

If there is a single connection set then it will never get past line 296 and will always satisfy
`$this->connection == $connection`
