### PR TITLE
No current folder creation on setup

### DIFF
--- a/src/Rocketeer/Traits/BashModules/Filesystem.php
+++ b/src/Rocketeer/Traits/BashModules/Filesystem.php
@@ -38,7 +38,7 @@ trait Filesystem
 			$this->move($symlink, $folder);
 		}
 
-		if (is_dir($folder) && ! is_link($folder)) {
+		if (is_dir($symlink) && ! is_link($symlink)) {
 			$this->removeFolder($symlink);
 		}
 

--- a/tests/Traits/BashModules/FilesystemTest.php
+++ b/tests/Traits/BashModules/FilesystemTest.php
@@ -33,6 +33,22 @@ class FilesystemTest extends RocketeerTestCase
 		$this->assertEquals($matcher, $share);
 	}
 
+	public function testCanOverwriteFolderWithSymlink()
+	{
+		// Create dummy folders
+		$folderCurrent = $this->server.'/dummy-current';
+		mkdir($folderCurrent);
+		$folderRelease = $this->server.'/dummy-release';
+		mkdir($folderRelease);
+
+		$this->bash->symlink($folderRelease, $folderCurrent);
+
+		clearstatcache();
+		$check = (is_dir($folderCurrent) && is_link($folderCurrent));
+
+		$this->assertTrue($check);
+	}
+
 	public function testCanListContentsOfAFolder()
 	{
 		$contents = $this->task->listContents($this->server);


### PR DESCRIPTION
Fixes #343 

There is no need to create an empty `current` folder.
