### PR TITLE
FIX: don't accidentally strip possible revision from url

### DIFF
--- a/src/Rocketeer/Scm/Svn.php
+++ b/src/Rocketeer/Scm/Svn.php
@@ -78,7 +78,7 @@ class Svn extends AbstractBinary implements ScmInterface
 		$branch     = $this->connections->getRepositoryBranch();
 		$repository = $this->connections->getRepositoryEndpoint();
 		$repository = rtrim($repository, '/').'/'.ltrim($branch, '/');
-		$repository = preg_replace('#[a-zA-Z0-9]+:?[a-zA-Z0-9]*@#', null, $repository);
+		$repository = preg_replace('#//[a-zA-Z0-9]+:?[a-zA-Z0-9]*@#', '//', $repository);
 
 		return $this->co([$repository, $destination], $this->getCredentials());
 	}


### PR DESCRIPTION
FIX: don't accidentally strip possible revision from url (like example.com/svn/trunk@123)
