### PR TITLE
possible solution to multiserver problem

### DIFF
--- a/src/Rocketeer/Services/Connections/ConnectionsHandler.php
+++ b/src/Rocketeer/Services/Connections/ConnectionsHandler.php
@@ -76,10 +76,6 @@ class ConnectionsHandler
             return 'local';
         }
 
-        if ($this->handle) {
-            return $this->handle;
-        }
-
         // Get identifiers
         $connection = $connection ?: $this->getConnection();
         $server     = $server ?: $this->getServer();

--- a/tests/Services/CredentialsGathererTest.php
+++ b/tests/Services/CredentialsGathererTest.php
@@ -311,7 +311,7 @@ class CredentialsGathererTest extends RocketeerTestCase
         ), $credentials);
 
         // also check handle generation as handles are used for connection cache keying in RemoteHandler
-        $this->assertEquals("production-multiserver/0", $this->connections->getHandle("production-multiserver", 0));
+        $this->assertEquals("production-multiserver/10.1.1.1", $this->connections->getHandle("production-multiserver", 0));
 
         $credentials = $this->connections->getServerCredentials('production-multiserver', 1);
         $this->assertEquals(array(
@@ -325,7 +325,7 @@ class CredentialsGathererTest extends RocketeerTestCase
             'db_role' => false
         ), $credentials);
 
-        $this->assertEquals("production-multiserver/1", $this->connections->getHandle("production-multiserver", 1));
+        $this->assertEquals("production-multiserver/10.1.1.2", $this->connections->getHandle("production-multiserver", 1));
 
         $credentials = $this->connections->getServerCredentials('production-multiserver', 2);
         $this->assertEquals(array(
@@ -339,7 +339,7 @@ class CredentialsGathererTest extends RocketeerTestCase
             'db_role' => false
         ), $credentials);
 
-        $this->assertEquals("production-multiserver/2", $this->connections->getHandle("production-multiserver", 2));
+        $this->assertEquals("production-multiserver/10.1.1.3", $this->connections->getHandle("production-multiserver", 2));
     }
 
     //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
@Anahkiasen. This is not a real pull request (yet). More of a way to provide some context to a discussion.

I have been writing an Rackspace open cloud plugin for Rocketeer that allows one to deploy to a load balanced autoscale group. As the autoscale group changes all the time, the ip addresses are potentially different each deploy.  During development and attempted use of this plugin I discovered a few issues. I will raise some issues shortly to hopefully cover those. 

The code below seems to be causing problem when I do a multi server deployment. Now I may have discovered a bug, or it maybe that I am just configuring rocketeer incorrectly. When I feed my 9 servers into a connection in config.php as an array I seem to get the deployment being attempted twice to the 1st server which then goes on to fail. 

The snippet below demonstrates what it looks like. The `$autoscale` method `addresses` returns an array of associative arrays as one would expect. 

    'production-autoscale' => array(
      'servers' => $autoscale->addresses('AUTOSCALE_GROUP_NAME', 'deploy', true)
    ),

Then during deployment I get 

production-autoscale/0 - OK 
production-autoscale/1 - OK 
production-autoscale/1 .. repeated (but fails after the first repeat). 

I tracked it down seemingly to the code I removed in the PR. I don't understand how Rocketeer hangs together enough to know why the handle is returned repeatedly? Some kind of optimisation? 

Any suggestions as to what the problem might be?

PS. I am loving Rockeeter by the way.  :heart: 