### PR TITLE
Added repository name as notify variable

### DIFF
--- a/src/Rocketeer/Services/Connections/ConnectionsHandler.php
+++ b/src/Rocketeer/Services/Connections/ConnectionsHandler.php
@@ -436,4 +436,16 @@ class ConnectionsHandler
 
 		return $branch;
 	}
+
+	/**
+	 * Get repository name to use
+	 *
+	 * @return  string
+	 */
+	public function getRepositoryName()
+	{
+		$repository = $this->getRepositoryCredentials();
+		$repository = Arr::get($repository, 'repository');
+		return str_replace('.git', '', basename($repository));
+	}
 }

--- a/src/Rocketeer/Tasks/Subtasks/Notify.php
+++ b/src/Rocketeer/Tasks/Subtasks/Notify.php
@@ -73,6 +73,7 @@ class Notify extends AbstractTask
 		}
 
 		// Get what was deployed
+		$repo       = $this->connections->getRepositoryName();
 		$branch     = $this->connections->getRepositoryBranch();
 		$stage      = $this->connections->getStage();
 		$connection = $this->connections->getConnection();
@@ -85,7 +86,7 @@ class Notify extends AbstractTask
 			$connection = $stage.'@'.$connection;
 		}
 
-		return compact('user', 'branch', 'connection', 'host');
+		return compact('user', 'branch', 'connection', 'host', 'repo');
 	}
 
 	/**


### PR DESCRIPTION
In some cases it would be beneficial to have the repository name available for messages as a 5th variable. My specific use-case was while using the slack plugin. I have many repositories, so having the message read like `austenc is deploying "repo_name:master" on "staging"` would be a lot more helpful. When you have several repositories, it's hard to tell which master branch was pushed up! Perhaps you know of a better way of getting the repository name, but this is what I came up with. If this PR is accepted I'll send one for the slack plugin config file comments too notating the new variable. 

Hopefully you find this helpful! Cheers!

**Edit: On second thought, one could manually include this info with their message in the config file, this just automates it.**

That's what I've done for now, but I'll leave this here in case you deem it useful. Thanks for rocketeer!