### PR TITLE
Sudo support

### DIFF
--- a/src/Rocketeer/Traits/BashModules/Core.php
+++ b/src/Rocketeer/Traits/BashModules/Core.php
@@ -39,6 +39,20 @@ trait Core
     {
         $this->local = $local;
     }
+    /**
+     * Whether to run the commands with sudo
+     *
+     * @type bool
+     */
+    protected static $sudo = false;
+
+    /**
+     * @param bool|string $sudo
+     */
+    public function setSudo($sudo)
+    {
+        self::$sudo = $sudo;
+    }
 
     /**
      * Get which Connection to call commands with.
@@ -314,6 +328,10 @@ trait Core
             // Create shell if asked
             if ($shell && Str::contains($command, $shelled)) {
                 $command = $this->shellCommand($command);
+            }
+            
+            if (self::$sudo) {
+                $command = 'sudo'.(is_string(self::$sudo) ? (' -u '.self::$sudo) : '') . ' ' . $command;
             }
         }
 


### PR DESCRIPTION
Adds the option to set globally option "sudo" to add to each command. If set true, it will prepend sudo to each command. If set with a user (string), it will prepend sudo -u user to each command.

Note you must add the user to sudoers with the :NOPASSWD option so as not to be prompted for password.