### PR TITLE
Prefer SCM branch from config before going to the server

### DIFF
--- a/src/Rocketeer/Services/Credentials/Keychains/RepositoriesKeychain.php
+++ b/src/Rocketeer/Services/Credentials/Keychains/RepositoriesKeychain.php
@@ -93,13 +93,15 @@ trait RepositoriesKeychain
             return $branch;
         }
 
-        // Compute the fallback branch
-        $fallback = $this->bash->onLocal(function () {
-            return $this->scm->runSilently('currentBranch');
-        });
-        $fallback = $fallback ?: 'master';
-        $fallback = trim($fallback);
-        $branch   = $this->rocketeer->getOption('scm.branch') ?: $fallback;
+        $branch = $this->rocketeer->getOption('scm.branch');
+        if (!$branch) {
+            // Compute the fallback branch
+            $fallback = $this->bash->onLocal(function () {
+                return $this->scm->runSilently('currentBranch');
+            });
+            $fallback = $fallback ?: 'master';
+            $branch = trim($fallback);
+        }
 
         return $branch;
     }


### PR DESCRIPTION
This saves a server call in instances where SCM branch is explicitly configured. Not only is it an optimization, but in some cases it's saved me initialization headaches... Of course, that's probably just me! 