### PR TITLE
Make symlinks relative to their location

### DIFF
--- a/src/Rocketeer/Services/Connections/Shell/Modules/Filesystem.php
+++ b/src/Rocketeer/Services/Connections/Shell/Modules/Filesystem.php
@@ -55,7 +55,7 @@ class Filesystem extends AbstractBashModule
 
         // Switch to relative if required
         if ($this->config->getContextually('remote.symlink') === 'relative') {
-            $folder = str_ireplace($this->paths->getFolder(''), '', $folder);
+            $folder = $this->getRelativePath($symlink, $folder);
         }
 
         switch ($this->environment->getOperatingSystem()) {
@@ -332,5 +332,89 @@ class Filesystem extends AbstractBashModule
             'tail',
             'upload',
         ];
+    }
+
+    /**
+     * Get a relative path from one file or directory to another.
+     *
+     * If $from is a path to a file (i.e. does not end with a "/"), the
+     * returned path will be relative to its parent directory.
+     *
+     * @param string $from
+     * @param string $to
+     *
+     * @return string
+     */
+    protected function getRelativePath($from, $to)
+    {
+        $from = $this->explodePath($from);
+        $to   = $this->explodePath($to);
+
+        $result = [];
+        $i      = 0;
+
+        // Skip the common path prefix
+        while ($i < count($from) && $i < count($to) && $from[$i] === $to[$i]) {
+            $i++;
+        }
+
+        // Add ".." for each directory left in $from
+        $from_length = count($from) - 1; // Path length without the filename
+        if ($i > 0 && $i < $from_length) {
+            $result = array_fill(0, $from_length - $i, '..');
+        }
+
+        // Add the remaining $to path
+        $result = array_merge($result, array_slice($to, $i));
+
+        return implode('/', $result);
+    }
+
+    /**
+     * Explode the given path into components, resolving any
+     * ".." components and ignoring "." and double separators.
+     *
+     * If the path starts at root directory, the first component
+     * will be empty.
+     *
+     * @param string $path
+     * @param string $separator Path separator to use, defaults to /.
+     *
+     * @return array
+     */
+    protected function explodePath($path, $separator = '/')
+    {
+        $result = [];
+
+        if (strpos($path, $separator) === 0) {
+            // Add empty component if the path starts at root directory
+            $result[] = '';
+        }
+
+        foreach (explode($separator, $path) as $component) {
+            switch ($component) {
+                case '..':
+                    // ".." removes the preceding component
+                    if (empty($result) || $result[count($result) - 1] === '..') {
+                        // Unless the path contains only ".." so far (then keep the "..")
+                        $result[] = '..';
+                        break;
+                    }
+                    if (count($result) === 1 && $result[0] === '') {
+                        // Or the path is already at root (then just ignore it)
+                        break;
+                    }
+                    array_pop($result);
+                    break;
+                case '.':
+                case '':
+                    // Ignore double separators and "."
+                    break;
+                default:
+                    $result[] = $component;
+            }
+        }
+
+        return $result;
     }
 }

--- a/tests/Services/Connections/Shell/Modules/FilesystemTest.php
+++ b/tests/Services/Connections/Shell/Modules/FilesystemTest.php
@@ -57,8 +57,8 @@ class FilesystemTest extends RocketeerTestCase
         $folder = '{path.base}/foobar.txt';
         $share = $task->share($folder);
         $tempLink = $this->server.'/releases/20000000000000//src/foobar.txt-temp';
-        $matcher = [
-            sprintf('ln -s %s %s', 'shared//src/foobar.txt', $tempLink, $tempLink),
+        $matcher  = [
+            sprintf('ln -s %s %s', '../../../shared/src/foobar.txt', $tempLink, $tempLink),
             sprintf('mv -Tf %s %s', $tempLink, $this->server.'/releases/20000000000000//src/foobar.txt'),
         ];
 


### PR DESCRIPTION
Symlinks are resolved at runtime from the context of their parent directory, so when creating relative symlinks, they need to be relative to the directory that the symlink is placed in and not the working directory the symlink was created from. For example, "/releases/123456789/src/file.txt" should be pointing to "../../../shared/src/file.txt".

In newer versions of GNU coreutils, you can use the "-r" argument to ln to calculate the appropriate relative path when creating the symlink, but older versions don't support that, so I've added a helper function to calculate the relative path manually.

There's a fair few edge cases when paths contain double separators or "." and ".." that I tried to account for, so the helper functions could really use some tests. However, I wasn't sure how to add tests for helper functions (I couldn't find any existing tests for helper functions to use as an example), so any suggestions are welcome and appreciated!