### PR TITLE
Check task sync case sensitivity

### DIFF
--- a/src/Rocketeer/Tasks/Check.php
+++ b/src/Rocketeer/Tasks/Check.php
@@ -44,7 +44,7 @@ class Check extends AbstractTask
         $errors = [];
 
         // Check the depoy strategy
-        if ($this->rocketeer->getOption('strategies.deploy') !== 'sync' && !$this->checkScm()) {
+        if ($this->rocketeer->getOption('strategies.deploy') !== 'Sync' && !$this->checkScm()) {
             $errors[] = $this->scm->getBinary().' could not be found';
         }
 

--- a/tests/Tasks/CheckTest.php
+++ b/tests/Tasks/CheckTest.php
@@ -25,7 +25,7 @@ class CheckTest extends RocketeerTestCase
     public function testSkipsScmCheckIfNotRequired()
     {
         $this->swapConfig([
-            'rocketeer::strategies.deploy' => 'sync',
+            'rocketeer::strategies.deploy' => 'Sync',
         ]);
 
         $this->assertTaskHistory('Check', [


### PR DESCRIPTION
In strategies.php, one of the valid bundled 'deploy' strategies can be 'Sync'.

In the Check task, however, a strict comparison is made against the string 'sync'.  This means that a SCM check is made regardless of preference, resulting in the Check task failing if there is no need for an SCM on the hosting server.

A valid user case for this would be a public web-server with an inaccessible SCM tucked behind a company firewall.

This pull request addresses the case sensitivity issue.

Updating the original test should be sufficient, however feel free to request additional if you feel they are necessary.