### PR TITLE
Check task sync case sensitivity

### DIFF
--- a/src/Rocketeer/Tasks/Check.php
+++ b/src/Rocketeer/Tasks/Check.php
@@ -82,7 +82,7 @@ class Check extends AbstractTask
     public function checkScm()
     {
         // Cancel if not using any SCM
-        if ($this->rocketeer->getOption('strategies.deploy') === 'sync') {
+        if ($this->rocketeer->getOption('strategies.deploy') === 'Sync') {
             return true;
         }
 

--- a/tests/Tasks/CheckTest.php
+++ b/tests/Tasks/CheckTest.php
@@ -31,7 +31,7 @@ class CheckTest extends RocketeerTestCase
         $this->usesComposer();
 
         $this->swapConfig([
-            'strategies.deploy' => 'sync',
+            'strategies.deploy' => 'Sync',
         ]);
 
         $this->assertTaskHistory('Check', [


### PR DESCRIPTION


In strategies.php, one of the valid bundled 'deploy' strategies can be 'Sync'.

In the Check task, however, a strict comparison is made against the string 'sync'. This means that a SCM check is made regardless of preference, resulting in the Check task failing if there is no need for an SCM on the hosting server.

A valid user case for this would be a public web-server with an inaccessible SCM tucked behind a company firewall.

This pull request addresses the case sensitivity issue.

Updating the original test should be sufficient, however feel free to request additional if you feel they are necessary.