### PR TITLE
Better error message if strategy cannot be built

### DIFF
--- a/src/Rocketeer/Services/Tasks/TasksBuilder.php
+++ b/src/Rocketeer/Services/Tasks/TasksBuilder.php
@@ -112,12 +112,14 @@ class TasksBuilder
         // build it, otherwise get the bound one
         $handle = strtolower($strategy);
         if ($concrete) {
-            $concrete = $this->findQualifiedName($concrete, [
-                'Rocketeer\Strategies\\'.ucfirst($strategy).'\%sStrategy',
-            ]);
+            $path       = 'Rocketeer\Strategies\\'.ucfirst($strategy).'\%sStrategy';
+            $class      = sprintf($path, $concrete);
+            $concrete   = $this->findQualifiedName($concrete, [$path]);
 
             if (!$concrete) {
-                return false;
+                throw new \RuntimeException(
+                    sprintf('Class "%s" for strategy "%s" not found', $class, $strategy)
+                );
             }
 
             return new $concrete($this->app);

--- a/src/Rocketeer/Services/Tasks/TasksBuilder.php
+++ b/src/Rocketeer/Services/Tasks/TasksBuilder.php
@@ -16,6 +16,7 @@ use Rocketeer\Abstracts\AbstractTask;
 use Rocketeer\Binaries\AnonymousBinary;
 use Rocketeer\Exceptions\TaskCompositionException;
 use Rocketeer\Traits\HasLocator;
+use RuntimeException;
 
 /**
  * Handles creating tasks from strings, closures, AbstractTask children, etc.
@@ -117,7 +118,7 @@ class TasksBuilder
             $concrete   = $this->findQualifiedName($concrete, [$path]);
 
             if (!$concrete) {
-                throw new \RuntimeException(
+                throw new RuntimeException(
                     sprintf('Class "%s" for strategy "%s" not found', $class, $strategy)
                 );
             }


### PR DESCRIPTION
I added a bit more of an informative error message as I originally changed the deploy strategy to 'Rsync' and just got a call to a method on a nob-object error. Consulting the code I should have specified 'Sync'.

This now throws an exception if the strategy does not exist. Forgive me if I've missed something, I've literally spent 5 minutes in the codebase. 