### PR TITLE
Backport #471 Fix after events firing when task failed to 2.x branch.

### DIFF
--- a/src/Rocketeer/Abstracts/AbstractTask.php
+++ b/src/Rocketeer/Abstracts/AbstractTask.php
@@ -142,7 +142,9 @@ abstract class AbstractTask extends Bash
             $this->timer->time($this, function () use (&$results) {
                 $results = $this->execute();
             });
-            $this->fireEvent('after');
+            if ($results && !$this->wasHalted()) {
+                $this->fireEvent('after');
+            }
         }
 
         return $results;

--- a/tests/Abstracts/AbstractTaskTest.php
+++ b/tests/Abstracts/AbstractTaskTest.php
@@ -116,7 +116,7 @@ class AbstractTaskTest extends RocketeerTestCase
         $this->pretend();
         $this->queue->run('Deploy');
 
-        $this->assertCount(18, $this->history->getFlattenedHistory());
+        $this->assertCount(14, $this->history->getFlattenedHistory());
     }
 
     public function testCanHookIntoHaltingEvent()
@@ -146,5 +146,19 @@ class AbstractTaskTest extends RocketeerTestCase
                                                ->mock();
 
         $this->task('CurrentRelease')->execute();
+    }
+
+    public function testDoesntRunAfterEventIfTaskFailed()
+    {
+        $this->expectOutputString('');
+
+        $task = 'Rocketeer\Dummies\Tasks\MyCustomHaltingTask';
+        $task = $this->builder->buildTask($task);
+
+        $this->tasks->after($task, function () {
+           echo 'fired';
+        });
+
+        $task->fire();
     }
 }


### PR DESCRIPTION
Hia,

I've backported the fix in #471 made to the develop branch to the master branch so that we can use it in the stable 2.2.x release. Having the after tasks trigger on a failed deployment was causing a lot of confusion for us. This might help other folks using the current stable 2.x release.

Unit tests pass ok I think and I was getting nice exit code 1 after failing to deploy and none of the deploy.after tasks were run.

I haven't bumped the version constant, not sure of the protocol here :)

Hope it's ok,
Cheers,
Chris.