### PR TITLE
Tasks, like Deploy, return null instead of a string when they succeed…

### DIFF
--- a/src/Rocketeer/Abstracts/AbstractTask.php
+++ b/src/Rocketeer/Abstracts/AbstractTask.php
@@ -142,7 +142,7 @@ abstract class AbstractTask extends Bash
             $this->timer->time($this, function () use (&$results) {
                 $results = $this->execute();
             });
-            if ($results && !$this->wasHalted()) {
+            if ($results !== false && !$this->wasHalted()) {
                 $this->fireEvent('after');
             }
         }


### PR DESCRIPTION
… - false is returned if the task was halted,so explicitly only checking false as a way to prevent after tasks being fired to allow nulls.

This could prevent after.deploy tasks from firing for folks using the master branch after PR https://github.com/rocketeers/rocketeer/pull/547 was merged.

Hope my understanding of the return value of AbtractTask->execute() is ok.

If I'm right about this, then you may need to do something similar (maybe you already have) in the 3.x dev branch as it looks like tasks like Deploy->execute still returns null.

Cheers,
Chris.