### PR TITLE
Fix fatal error due to missing Carbon classes

### DIFF
--- a/box.json
+++ b/box.json
@@ -19,8 +19,6 @@
       "exclude": [
         "tests",
 
-        "nesbot",
-
         "johnkary",
         "mockery",
         "nesbot",


### PR DESCRIPTION
This fixes the following error which may occur with the `.phar`:

> Fatal error: Class 'Carbon\Carbon' not found in .../LocalCloneStrategy.php on line 85