### PR TITLE
Fix fatal error due to missing Carbon classes

### DIFF
--- a/box.json
+++ b/box.json
@@ -19,11 +19,8 @@
       "exclude": [
         "tests",
 
-        "nesbot",
-
         "johnkary",
         "mockery",
-        "nesbot",
         "phpdocumentor",
         "phpspec",
         "phpunit",


### PR DESCRIPTION
This fixes the following error which may occur with the `rocketeer.phar`:

> Fatal error: Class 'Carbon\Carbon' not found in .../LocalCloneStrategy.php on line 85