### PR TITLE
Avoid exception when setting strategy to false or null

### DIFF
--- a/src/Rocketeer/Services/Tasks/TasksBuilder.php
+++ b/src/Rocketeer/Services/Tasks/TasksBuilder.php
@@ -126,6 +126,10 @@ class TasksBuilder
             return new $concrete($this->app);
         }
 
+        if (!isset($this->app['rocketeer.strategies.'.$handle])) {
+            return false;
+        }
+
         return $this->app['rocketeer.strategies.'.$handle];
     }
 


### PR DESCRIPTION
This fixes #531 and is also related to #435 and #602, where #435 actually shouldn't be closed because the suggested fix does not work without the change in this pull request.

There is a check in `bindStrategies()` of the `RocketeerServiceProvider` which checks if the setting is a string or not and if yes binds the corresponding class to the service container. 

In `buildStrategy()` of `src/Rocketeer/Services/Tasks/TaskBuilder.php` this check is missing, although the function is directly called. So this change just checks whether the binding exists and returns `false` like already mentioned in the docblock.
```
[ReflectionException]
  Class rocketeer.strategies.dependencies does not exist
```

I hope this doesn't break anything, I have just started looking at the rocketeer sources, tests are passing though.

I make this pull request to the master branch instead of the develop branch because develop does look quite different and more like the next major version.



 