### PR TITLE
fix to process unsecure http git repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ vendor
 
 # PhpUnit configuration local machine only
 phpunit.xml
+
+#IDE env
+.idea

--- a/src/Rocketeer/Services/Credentials/Keychains/RepositoriesKeychain.php
+++ b/src/Rocketeer/Services/Credentials/Keychains/RepositoriesKeychain.php
@@ -74,9 +74,13 @@ trait RepositoriesKeychain
             $credentials = $password ? $username.':'.$password : $username;
             $credentials .= '@';
 
-            // Add them in chain
+            // Add them in chain (for secure protocol)
             $repository = preg_replace('#https://(.+)@#', 'https://', $repository);
             $repository = str_replace('https://', 'https://'.$credentials, $repository);
+
+            //unsecure protocol repository access is also possible
+            $repository = preg_replace('#http://(.+)@#', 'http://', $repository);
+            $repository = str_replace('http://', 'http://'.$credentials, $repository);
         }
 
         return $repository;


### PR DESCRIPTION
fix the issue when access to a repository is by http (not ssh and not https). Credentials are not passed in this case but required.