### PR TITLE
Add missing direct dependency symfony/finder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
 		"symfony/process": "^3.1",
 		"symfony/var-dumper": "^3.1",
 		"symfony/yaml": "^3.1",
+		"symfony/finder": "~2.1 || ~3.0",
 		"vlucas/phpdotenv": "^2.3"
 	},
 	"require-dev": {


### PR DESCRIPTION
Looks like Rocketeer requires `symfony/finder` which is only loaded implicitly via your require-dev for `kherge/box`.

Reproduction steps:
1. `composer install --no-dev`
2. `php bin/rocketeer`

Error message:
```
PHP Fatal error:  Uncaught Error: Class 'Symfony\Component\Finder\Finder' not found in /home/martin/webs/rocketeer/src/Rocketeer/Services/Config/Files/Finders/AbstractConfigurationFinder.php:72
Stack trace:
#0 /home/martin/webs/rocketeer/src/Rocketeer/Services/Config/Files/Finders/AbstractConfigurationFinder.php(60): Rocketeer\Services\Config\Files\Finders\AbstractConfigurationFinder->getFinderForFolders(Array)
#1 /home/martin/webs/rocketeer/src/Rocketeer/Services/Config/Files/Finders/MainConfigurationFinder.php(27): Rocketeer\Services\Config\Files\Finders\AbstractConfigurationFinder->getFinder('/home/martin/we...')
#2 /home/martin/webs/rocketeer/src/Rocketeer/Services/Config/Files/Loaders/ConfigurationLoader.php(146): Rocketeer\Services\Config\Files\Finders\MainConfigurationFinder->getFiles()
#3 /home/martin/webs/rocketeer/src/Rocketeer/Services/Config/Files/Loaders/CachedConfigurationLoader.php(84): Rocketeer\Services\Config\Files\Loaders\ConfigurationLoader->getFiles()
#4 /home/martin/webs/rocketeer/src/Rocketeer/Services/C in /home/martin/webs/rocketeer/src/Rocketeer/Services/Config/Files/Finders/AbstractConfigurationFinder.php on line 72
```

Fixed by adding it as direct dependency. 