### PR TITLE
Errors with config

### DIFF
--- a/src/Rocketeer/Services/Ignition/RocketeerIgniter.php
+++ b/src/Rocketeer/Services/Ignition/RocketeerIgniter.php
@@ -87,6 +87,7 @@ class RocketeerIgniter
             $fileDestination = $destination.DS.$basename;
 
             if ($namespace) {
+                $namespace = preg_replace("/[^\w]/", "", $namespace);// only words allowed
                 $contents = str_replace('namespace App', 'namespace '.$namespace, $contents);
                 $contents = str_replace('AppServiceProvider', $namespace.'ServiceProvider', $contents);
                 $fileDestination = strpos($basename, 'ServiceProvider') === false

--- a/src/Rocketeer/Services/Ignition/RocketeerIgniter.php
+++ b/src/Rocketeer/Services/Ignition/RocketeerIgniter.php
@@ -41,7 +41,8 @@ class RocketeerIgniter
         // Build dotenv file
         $dotenv = '';
         foreach ($credentials as $credential => $value) {
-            $dotenv .= $credential.'='.$value.PHP_EOL;
+            $value = str_replace("\"", "\\\"", $value);
+            $dotenv .= sprintf('%s="%s"' . PHP_EOL, $credential, $value);
         }
 
         // Write to disk

--- a/src/Rocketeer/Services/Ignition/RocketeerIgniter.php
+++ b/src/Rocketeer/Services/Ignition/RocketeerIgniter.php
@@ -42,7 +42,8 @@ class RocketeerIgniter
         $dotenv = '';
         foreach ($credentials as $credential => $value) {
             $value = str_replace("\"", "\\\"", $value);
-            $dotenv .= sprintf('%s="%s"' . PHP_EOL, $credential, $value);
+            $dotenv .= sprintf('%s="%s"', $credential, $value);
+            $dotenv .= PHP_EOL;
         }
 
         // Write to disk

--- a/tests/Tasks/IgniteTest.php
+++ b/tests/Tasks/IgniteTest.php
@@ -37,7 +37,7 @@ class IgniteTest extends RocketeerTestCase
         ]);
 
         $dotenvPath = $this->paths->getDotenvPath();
-        $this->files->put($dotenvPath, 'FOO=bar');
+        $this->files->put($dotenvPath, 'FOO="bar"' . PHP_EOL);
 
         $this->task('Ignite')->execute();
 
@@ -45,8 +45,8 @@ class IgniteTest extends RocketeerTestCase
         $dotenv = $this->files->read($dotenvPath);
 
         $this->assertContains("'application_name' => 'foobar'", $config);
-        $this->assertContains('FOO=bar', $dotenv);
-        $this->assertContains('VCS_REPOSITORY=git@github.com/rocketeers/website.git', $dotenv);
+        $this->assertContains('FOO="bar"', $dotenv);
+        $this->assertContains('VCS_REPOSITORY="git@github.com/rocketeers/website.git"', $dotenv);
     }
 
     public function testCanIgniteStubs()


### PR DESCRIPTION
If you set application name with "." for example ```app.name```, then app is crashed.
Rocketeer will generate wrong namespace 
```namespace app.name``` which is illegal.
If you set spaces in settings, then wrong dot env file will be generated and the app will crash. Escaping is needed in that case.