### PR TITLE
Fixes to multiservers Copy strategy

### DIFF
--- a/src/Rocketeer/Services/Connections/Shell/Bash.php
+++ b/src/Rocketeer/Services/Connections/Shell/Bash.php
@@ -64,7 +64,7 @@ class Bash implements ModulableInterface, ContainerAwareInterface
      */
     public function on($connection, callable $callback)
     {
-        $current = $this->connections->getCurrentConnectionKey()->name;
+        $current = $this->connections->getCurrentConnectionKey();
 
         $this->connections->setCurrentConnection($connection);
         $results = $callback($this);

--- a/src/Rocketeer/Services/Connections/Shell/Modules/Flow.php
+++ b/src/Rocketeer/Services/Connections/Shell/Modules/Flow.php
@@ -45,9 +45,9 @@ class Flow extends AbstractBashModule
     {
         // Check if local is ready for deployment
         return $this->modulable->on('local', function () {
-            if (!$this->modulable->executeTask('Primer')) {
-                return $this->modulable->halt('Project is not ready for deploy. You were almost fired.');
-            }
+            $primer = $this->modulable->executeTask('Primer');
+
+            return $primer ?: $this->modulable->halt('Project is not ready for deploy. You were almost fired.');
         });
 
         if (!$this->isSetup()) {

--- a/src/Rocketeer/Services/Releases/ReleasesManager.php
+++ b/src/Rocketeer/Services/Releases/ReleasesManager.php
@@ -67,7 +67,7 @@ class ReleasesManager
     public function getReleases()
     {
         // Get releases on server
-        $connection = $this->connections->getCurrentConnectionKey()->name;
+        $connection = $this->connections->getCurrentConnectionKey()->toHandle();
         if (!array_key_exists($connection, $this->releases)) {
             $releases = $this->paths->getReleasesFolder();
             $releases = (array) $this->bash->listContents($releases);

--- a/src/Rocketeer/Strategies/Rollback/RollbackStrategyInterface.php
+++ b/src/Rocketeer/Strategies/Rollback/RollbackStrategyInterface.php
@@ -12,6 +12,9 @@
 
 namespace Rocketeer\Strategies\Rollback;
 
+/**
+ * Interface for Rollback strategies
+ */
 interface RollbackStrategyInterface
 {
     /**

--- a/src/Rocketeer/Strategies/Rollback/RollingStrategy.php
+++ b/src/Rocketeer/Strategies/Rollback/RollingStrategy.php
@@ -14,6 +14,9 @@ namespace Rocketeer\Strategies\Rollback;
 
 use Rocketeer\Strategies\AbstractStrategy;
 
+/**
+ * Uses a system of folders current/releases/shared to roll releases.
+ */
 class RollingStrategy extends AbstractStrategy implements RollbackStrategyInterface
 {
     /**

--- a/tests/Services/Connections/Shell/BashTest.php
+++ b/tests/Services/Connections/Shell/BashTest.php
@@ -12,6 +12,7 @@
 
 namespace Rocketeer\Services\Connections\Shell;
 
+use Rocketeer\Services\Connections\Credentials\Keys\ConnectionKey;
 use Rocketeer\TestCases\RocketeerTestCase;
 
 class BashTest extends RocketeerTestCase
@@ -21,5 +22,24 @@ class BashTest extends RocketeerTestCase
         $contents = $this->bash->runRaw('ls', true, true);
 
         $this->assertListDirectory($contents);
+    }
+
+    public function testCanSwitchBackToCorrectServer()
+    {
+        $this->swapConnections([
+            'production' => [
+                'servers' => [
+                    ['host' => 'foo.com'],
+                    ['host' => 'bar.com'],
+                ],
+            ],
+        ]);
+
+        $this->connections->setCurrentConnection('production', 1);
+        $this->bash->on('local', function() {
+
+        });
+
+        $this->assertEquals(1, $this->connections->getCurrentConnectionKey()->server);
     }
 }

--- a/tests/Services/Connections/Shell/BashTest.php
+++ b/tests/Services/Connections/Shell/BashTest.php
@@ -12,7 +12,6 @@
 
 namespace Rocketeer\Services\Connections\Shell;
 
-use Rocketeer\Services\Connections\Credentials\Keys\ConnectionKey;
 use Rocketeer\TestCases\RocketeerTestCase;
 
 class BashTest extends RocketeerTestCase
@@ -36,8 +35,7 @@ class BashTest extends RocketeerTestCase
         ]);
 
         $this->connections->setCurrentConnection('production', 1);
-        $this->bash->on('local', function() {
-
+        $this->bash->on('local', function () {
         });
 
         $this->assertEquals(1, $this->connections->getCurrentConnectionKey()->server);

--- a/tests/Services/Connections/Shell/Modules/FlowTest.php
+++ b/tests/Services/Connections/Shell/Modules/FlowTest.php
@@ -57,4 +57,9 @@ class FlowTest extends RocketeerTestCase
             ],
         ]);
     }
+
+    public function testDoesntFailIfPrimerSucceedsSilently()
+    {
+        $this->assertTrue($this->bash->setupIfNecessary());
+    }
 }

--- a/tests/TestCases/Modules/Assertions.php
+++ b/tests/TestCases/Modules/Assertions.php
@@ -255,8 +255,9 @@ trait Assertions
         $flattened = implode(Arr::flatten($obtained));
         preg_match_all('/[0-9]{14}/', $flattened, $releases);
         $release = Arr::get($releases, '0.0', date('YmdHis'));
-        if (substr($release, -5) === '00000') {
-            $release = Arr::get($releases, '0.1', date('YmdHis'));
+        $nextRelease = Arr::get($releases, '0.1');
+        if (substr($release, -5) === '00000' && $nextRelease && substr($nextRelease, -5) !== "0000") {
+            $release = $nextRelease ?: date('YmdHis');
         }
 
         // Look for times

--- a/tests/TestCases/Modules/Assertions.php
+++ b/tests/TestCases/Modules/Assertions.php
@@ -176,7 +176,7 @@ trait Assertions
     /**
      * Assert the history contains a particular entry.
      *
-     * @param array $expected
+     * @param string|string[] $expected
      */
     public function assertHistoryContains($expected)
     {
@@ -255,7 +255,7 @@ trait Assertions
         $flattened = implode(Arr::flatten($obtained));
         preg_match_all('/[0-9]{14}/', $flattened, $releases);
         $release = Arr::get($releases, '0.0', date('YmdHis'));
-        if ($release === '10000000000000') {
+        if (substr($release, -5) === '00000') {
             $release = Arr::get($releases, '0.1', date('YmdHis'));
         }
 


### PR DESCRIPTION
### Fixed
- Fixed releases not being scoped to current server
- Fixed `on()` method not switching back to correct server after callback

---

Closes #697, #483 
