### PR TITLE
added port support to config

### DIFF
--- a/src/Rocketeer/Services/Config/Definition/ConnectionsDefinition.php
+++ b/src/Rocketeer/Services/Config/Definition/ConnectionsDefinition.php
@@ -128,6 +128,7 @@ class ConnectionsDefinition extends AbstractDefinition
                     ->prototype('array')
                         ->children()
                             ->scalarNode('host')->defaultValue($connection->host)->end()
+                            ->scalarNode('port')->defaultValue($connection->port)->end()
                             ->scalarNode('username')->defaultValue($connection->username)->end()
                             ->scalarNode('password')->defaultValue($connection->password)->end()
                             ->scalarNode('key')->defaultValue($connection->key)->end()

--- a/src/Rocketeer/Services/Connections/Credentials/Keys/ConnectionKey.php
+++ b/src/Rocketeer/Services/Connections/Credentials/Keys/ConnectionKey.php
@@ -16,6 +16,7 @@ namespace Rocketeer\Services\Connections\Credentials\Keys;
  * Represents a connection's identity and its credential.
  *
  * @property string   $host
+ * @property string   $port
  * @property string   $username
  * @property string   $password
  * @property string   $key

--- a/src/Rocketeer/Services/Filesystem/ConnectionKeyAdapterFactory.php
+++ b/src/Rocketeer/Services/Filesystem/ConnectionKeyAdapterFactory.php
@@ -34,6 +34,7 @@ class ConnectionKeyAdapterFactory
 
         return new $adapter([
             'host' => $connectionKey->host,
+            'port' => $connectionKey->port,
             'username' => $connectionKey->username,
             'password' => $connectionKey->password,
             'privateKey' => $connectionKey->key,


### PR DESCRIPTION
### Fixed
Added port support to config

Now you can set port in your config
```
'production' => [
   'servers' => [
        'host' => '%%PRODUCTION_HOST%%',
        'port' => '%%PRODUCTION_PORT%%',
        'username' => '%%PRODUCTION_USERNAME%%',
        'password' => null,
        'key' => '%%PRODUCTION_KEY%%',
        'keyphrase' => '%%PRODUCTION_KEYPHRASE%%',
        'agent' => true,
]]
```


---

References #756 
